### PR TITLE
feat: Enable multi-category filtering and deep linking from categories page

### DIFF
--- a/resources/js/components/product-filters.tsx
+++ b/resources/js/components/product-filters.tsx
@@ -11,7 +11,7 @@ import { Slider } from '@/components/ui/slider';
 export function ProductFilters({
     categories,
     selectedCategories,
-    setSelectedCategories,
+    onCategoryChange,
     priceRange,
     setPriceRange,
     minPrice,
@@ -19,17 +19,21 @@ export function ProductFilters({
 }: {
     categories: { id: number; name: string }[];
     selectedCategories: string[];
-    setSelectedCategories: Dispatch<SetStateAction<string[]>>;
+    onCategoryChange: (newCategories: string[]) => void;
     priceRange: [number, number];
     setPriceRange: Dispatch<SetStateAction<[number, number]>>;
     minPrice: number;
     maxPrice: number;
 }) {
-    const handleCategoryChange = (category: string) => {
-        setSelectedCategories((prev) => (prev.includes(category) ? prev.filter((c) => c !== category) : [...prev, category]));
+    const handleCategoryToggle = (category: string) => {
+        if (selectedCategories.includes(category)) {
+            onCategoryChange(selectedCategories.filter((c) => c !== category));
+        } else {
+            onCategoryChange([...selectedCategories, category]);
+        }
     };
     const handleClear = () => {
-        setSelectedCategories([]);
+        onCategoryChange([]);
         setPriceRange([minPrice, maxPrice]);
     };
     return (
@@ -53,7 +57,7 @@ export function ProductFilters({
                                 <Checkbox
                                     id={`category-${category.name}`}
                                     checked={selectedCategories.includes(category.name)}
-                                    onCheckedChange={() => handleCategoryChange(category.name)}
+                                    onCheckedChange={() => handleCategoryToggle(category.name)}
                                 />
                                 <label
                                     htmlFor={`category-${category.name}`}

--- a/resources/js/pages/categories.tsx
+++ b/resources/js/pages/categories.tsx
@@ -29,7 +29,7 @@ export default function CategoriesPage({ categories }: { categories: Category[] 
                     {categories.map((category) => (
                         <Link
                             key={category.name}
-                            href={`/categories/${category.id}`}
+                            href={`/products?category=${encodeURIComponent(category.name)}`}
                             className="group overflow-hidden rounded-lg border shadow-sm transition-all hover:scale-105 hover:shadow-md"
                         >
                             <div className="aspect-[4/3] w-full overflow-hidden">


### PR DESCRIPTION
Updated products page to support multiple category filters via URL query (?categories=Chair,Table)

Modified backend to accept and filter products by multiple categories

Improved frontend logic: selecting/deselecting categories updates the URL in real-time

Added support for clearing all category filters to reset product list

Implemented category click behavior from the categories page to pre-select a filter and redirect to the products page